### PR TITLE
add background option to dimensions only when image library is vips

### DIFF
--- a/lib/vitals_image/optimizer/variable.rb
+++ b/lib/vitals_image/optimizer/variable.rb
@@ -81,7 +81,12 @@ module VitalsImage
       end
 
       def resize_and_flatten(defaults = {})
-        resize  = resize_mode != :resize_and_pad ? dimensions : dimensions.push(background: [255])
+        if resize_mode == :resize_and_pad && VitalsImage.image_library == :vips
+          resize = dimensions.push(background: [255])
+        else
+          resize = dimensions
+        end
+
         defaults.merge "#{resize_mode}": resize
       end
 

--- a/test/analyzer/url_analyzer_test.rb
+++ b/test/analyzer/url_analyzer_test.rb
@@ -27,15 +27,5 @@ module VitalsImage
         assert vitals_image_sources(:cat).analyzed
       end
     end
-
-    private
-      def with_image_library(library)
-        previous_library = VitalsImage.image_library
-        VitalsImage.image_library = library
-
-        yield
-      ensure
-        VitalsImage.image_library = previous_library
-      end
   end
 end

--- a/test/optimizer/variable_test.rb
+++ b/test/optimizer/variable_test.rb
@@ -125,14 +125,16 @@ module VitalsImage
     end
 
     test "that a height and width can be chosen for an existing image of an object in a white background and it will be padded" do
-      existing_jpeg_with_dimensions(150, 150, white_background: true) do |image|
-        assert_equal [300, 300], image.src.variation.transformations[:resize_and_pad]
+      with_image_library(:mini_magick) do
+        existing_jpeg_with_dimensions(150, 150, white_background: true) do |image|
+          assert_equal [300, 300], image.src.variation.transformations[:resize_and_pad]
+        end
       end
 
-      VitalsImage.image_library = :vips
-
-      existing_jpeg_with_dimensions(150, 150, white_background: true) do |image|
-        assert_equal [300, 300, background: [255]], image.src.variation.transformations[:resize_and_pad]
+      with_image_library(:vips) do
+        existing_jpeg_with_dimensions(150, 150, white_background: true) do |image|
+          assert_equal [300, 300, background: [255]], image.src.variation.transformations[:resize_and_pad]
+        end
       end
     end
 

--- a/test/optimizer/variable_test.rb
+++ b/test/optimizer/variable_test.rb
@@ -126,6 +126,12 @@ module VitalsImage
 
     test "that a height and width can be chosen for an existing image of an object in a white background and it will be padded" do
       existing_jpeg_with_dimensions(150, 150, white_background: true) do |image|
+        assert_equal [300, 300], image.src.variation.transformations[:resize_and_pad]
+      end
+
+      VitalsImage.image_library = :vips
+
+      existing_jpeg_with_dimensions(150, 150, white_background: true) do |image|
         assert_equal [300, 300, background: [255]], image.src.variation.transformations[:resize_and_pad]
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,3 +21,12 @@ end
 def create_file_blob(filename:, content_type:, metadata: nil)
   ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
 end
+
+def with_image_library(library)
+  previous_library = VitalsImage.image_library
+  VitalsImage.image_library = library
+
+  yield
+ensure
+  VitalsImage.image_library = previous_library
+end


### PR DESCRIPTION
When we have a square image, and we want to display it as a rectangle, the resize mode `:resize_and_pad` resized image is filled with white color. When we use `imagick`, the option `background: [255]` added to dimensions array doesn't work because this option is only available for `vips`.