### PR TITLE
Fix (VIN-3062): Autoload Cache to apply app configurations on ActiveRecord

### DIFF
--- a/lib/vitals_image/cache.rb
+++ b/lib/vitals_image/cache.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../app/models/vitals_image/source"
-
 module VitalsImage
   class Cache
     include Singleton


### PR DESCRIPTION
O `require_relative` faz com que o ActiveRecord seja carregado antes das configurações do app serem carregadas e aplicadas.
Com o autoload do rails as configurações passam a ser aplicadas corretamente