### PR TITLE
Fix for Update dependencies 2025-12-08

### DIFF
--- a/lib/vitals_image/engine.rb
+++ b/lib/vitals_image/engine.rb
@@ -23,6 +23,8 @@ require "vitals_image/optimizer/variable"
 require "vitals_image/optimizer/invariable"
 require "vitals_image/optimizer/unoptimizable"
 require "vitals_image/tiny_gif"
+require_relative "../../app/helpers/vitals_image/tag_helper"
+
 
 module VitalsImage
   class Engine < ::Rails::Engine

--- a/lib/vitals_image/engine.rb
+++ b/lib/vitals_image/engine.rb
@@ -34,8 +34,6 @@ module VitalsImage
     config.vitals_image.domains                         = []
 
     config.eager_load_namespaces << VitalsImage
-    # Add engine helpers to Rails' paths: autoload in development, eager load in production
-    config.paths.add "app/helpers/vitals_image/tag_helper", eager_load: true, autoload: true
 
     initializer "vitals_image.configs" do
       config.after_initialize do |app|

--- a/lib/vitals_image/engine.rb
+++ b/lib/vitals_image/engine.rb
@@ -23,6 +23,7 @@ require "vitals_image/optimizer/variable"
 require "vitals_image/optimizer/invariable"
 require "vitals_image/optimizer/unoptimizable"
 require "vitals_image/tiny_gif"
+require_relative "../../app/helpers/vitals_image/tag_helper"
 
 module VitalsImage
   class Engine < ::Rails::Engine
@@ -86,7 +87,7 @@ module VitalsImage
       end
     end
 
-    config.to_prepare do
+    initializer "vitals_image.action_controller" do
       ActiveSupport.on_load :action_controller do
         helper VitalsImage::TagHelper
       end

--- a/lib/vitals_image/engine.rb
+++ b/lib/vitals_image/engine.rb
@@ -23,7 +23,6 @@ require "vitals_image/optimizer/variable"
 require "vitals_image/optimizer/invariable"
 require "vitals_image/optimizer/unoptimizable"
 require "vitals_image/tiny_gif"
-require_relative "../../app/helpers/vitals_image/tag_helper"
 
 module VitalsImage
   class Engine < ::Rails::Engine
@@ -35,6 +34,8 @@ module VitalsImage
     config.vitals_image.domains                         = []
 
     config.eager_load_namespaces << VitalsImage
+    # Add engine helpers to Rails' paths: autoload in development, eager load in production
+    config.paths.add "app/helpers/vitals_image/tag_helper", eager_load: true, autoload: true
 
     initializer "vitals_image.configs" do
       config.after_initialize do |app|
@@ -87,7 +88,7 @@ module VitalsImage
       end
     end
 
-    initializer "vitals_image.action_controller" do
+    config.to_prepare do
       ActiveSupport.on_load :action_controller do
         helper VitalsImage::TagHelper
       end

--- a/lib/vitals_image/engine.rb
+++ b/lib/vitals_image/engine.rb
@@ -23,7 +23,6 @@ require "vitals_image/optimizer/variable"
 require "vitals_image/optimizer/invariable"
 require "vitals_image/optimizer/unoptimizable"
 require "vitals_image/tiny_gif"
-require_relative "../../app/helpers/vitals_image/tag_helper"
 
 module VitalsImage
   class Engine < ::Rails::Engine
@@ -87,10 +86,10 @@ module VitalsImage
       end
     end
 
-    initializer "vitals_image.action_controller" do
-      ActiveSupport.on_load :action_controller do
-        helper VitalsImage::TagHelper
-      end
-    end
+    config.to_prepare do
+     ActiveSupport.on_load :action_controller do
+       helper VitalsImage::TagHelper
+     end
+   end
   end
 end

--- a/lib/vitals_image/engine.rb
+++ b/lib/vitals_image/engine.rb
@@ -25,7 +25,6 @@ require "vitals_image/optimizer/unoptimizable"
 require "vitals_image/tiny_gif"
 require_relative "../../app/helpers/vitals_image/tag_helper"
 
-
 module VitalsImage
   class Engine < ::Rails::Engine
     isolate_namespace VitalsImage


### PR DESCRIPTION
https://github.com/FestaLab/festalab-app/pull/9120

This PR will be needed to fix the following error that was happening after de bundle upgrade on our dependency updates.
The error was happening on line 91 of the **vitals_image/lib/vitals_image/engine.rb:** file, when we called the TagHelper before it was initialized by the application. 

**"bin/rails aborted!
18:58:58 web.1  | /home/lucas/code/Festalab/vitals_image/lib/vitals_image/engine.rb:91:in 'block (2 levels) in <class:Engine>': uninitialized constant VitalsImage::TagHelper (NameError)
18:58:58 web.1  |         helper VitalsImage::TagHelper
18:58:58 web.1  | from /home/lucas/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/bundler/gems/rails-45d7ba97b07e/activesupport/lib/active_support/lazy_load_hooks.rb:97:in 'Module#class_eval'**